### PR TITLE
change method of differentiating between players

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ app.on('ready', function() {
         });
         apple.detectPlayer().then(result => {
             console.log("Player detected: "+result);
-            apple.replacePlayer(result);
+            // apple.replacePlayer(result);
         }).catch(error => process.exit())
         if (apple.rememberUser() === false){
             app.emit('loginOpen');

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ app.on('ready', function() {
         });
         apple.detectPlayer().then(result => {
             console.log("Player detected: "+result);
-            // apple.replacePlayer(result);
         }).catch(error => process.exit())
         if (apple.rememberUser() === false){
             app.emit('loginOpen');

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -4,66 +4,29 @@ const { app } = require('electron')
 var AutoLaunch = require('auto-launch');
 const lastfm = require('./lastfm-controller');
 var fs = require('fs');
+process.player = "Music";
 
 /*
 Detects what player is installed on user's computer (iTunes or Apple Music).
 */
 function detectPlayer() {
     return new Promise(function(resolve, reject) {
-        osascript.executeFile(__dirname+'/applescript/detect.scpt', function(err, result, raw){
+        osascript.executeFile(__dirname + '/applescript/detect.scpt', function(err, result, raw){
             if (err) reject(Error(err));
             if (result == false) {
+                process.player =  "iTunes"
                 resolve("iTunes")
             }
             else if (result == true) {
+                process.player = "Music"
                 resolve("Music")
             } 
             else {
+                process.player = "iTunes"
                 resolve("Music")
             }
         });
     });
-}
-
-/*
-Replaces string x with a name of the player in the file applescript/nowplaying.scpt
-*/
-async function replacePlayer(player) {   
-    fs.readFile(__dirname+'/applescript/nowplaying.scpt', 'utf8', function (err,data) {
-        if (err) {
-            return console.log(err);
-        }
-        var attempt = data.replace(/0x/g, player);
-        var attempt2 = attempt.replace(/iTunes/g, player);
-        var result = attempt2.replace(/Music/g, player);
-        fs.writeFile(__dirname+'/applescript/nowplaying.scpt', result, 'utf8', function (err) {
-            if (err) return console.log(err);
-        });
-    });
-    fs.readFile(__dirname+'/applescript/state.scpt', 'utf8', function (err,data) {
-        if (err) {
-            return console.log(err);
-        }
-        console.log(data);
-        var attempt = data.replace(/0x/g, player);
-        var attempt2 = attempt.replace(/iTunes/g, player);
-        var result = attempt2.replace(/Music/g, player);
-        fs.writeFile(__dirname+'/applescript/state.scpt', result, 'utf8', function (err) {
-            if (err) return console.log(err);
-        });
-    });
-     fs.readFile(__dirname+'/applescript/loop.scpt', 'utf8', function (err,data) {
-        if (err) {
-            return console.log(err);
-        }
-        console.log(data);
-        var attempt = data.replace(/0x/g, player);
-        var attempt2 = attempt.replace(/iTunes/g, player);
-        var result = attempt2.replace(/Music/g, player);
-        fs.writeFile(__dirname+'/applescript/loop.scpt', result, 'utf8', function (err) {
-            if (err) return console.log(err);
-        });
-    });       
 }
 
 /*
@@ -71,7 +34,7 @@ Promise checking the state of a player.
 */
 function getPlayerState() {
     return new Promise(function(resolve, reject) {
-        osascript.executeFile(__dirname+'/applescript/state.scpt', function(err, result, raw){
+        osascript.executeFile(__dirname +'/applescript/' + process.player + '/state.scpt', function(err, result, raw){
             if (err) reject(err);
             resolve(result);
         });   
@@ -83,7 +46,7 @@ Promise checking if player is in the loop mode
 */
 function getLoopMode() {
     return new Promise(function(resolve, reject) {
-        osascript.executeFile(__dirname+'/applescript/loop.scpt', function(err, result, raw){
+        osascript.executeFile(__dirname+'/applescript/' + process.player + 'loop.scpt', function(err, result, raw){
             if (err) reject(err);
             resolve(result);
         });         
@@ -229,7 +192,7 @@ function autoLaunchEnabled() {
 
 module.exports = {
     detectPlayer,
-    replacePlayer,
+    // replacePlayer,
     savePreferences,
     rememberUser,
     autoLaunchEnable,

--- a/lib/applescript/Music/loop.scpt
+++ b/lib/applescript/Music/loop.scpt
@@ -1,0 +1,11 @@
+on run
+    set info to ""
+    tell application id "com.apple.Music"
+        if song repeat is off then
+            set playerStateText to false
+        else if song repeat is one or song repeat is all then
+            set playerStateText to true
+        end if
+    end tell
+    return playerStateText
+end run

--- a/lib/applescript/Music/nowplaying.scpt
+++ b/lib/applescript/Music/nowplaying.scpt
@@ -1,0 +1,47 @@
+on run
+	set info to ""
+	tell application id "com.apple.systemevents"
+		set num to count (every process whose bundle identifier is "com.apple.Music")
+	end tell
+	if num > 0 then
+		tell application id "com.apple.Music"
+			if player state is playing then
+				set track_name to name of current track
+				set track_artist to the artist of the current track
+				set track_album to the album of the  current track
+                set track_duration to (get duration of the current track)
+			end if
+		end tell
+	end if
+	return "{'artist':'" & encodeText(track_artist, false, false) & "', 'track': '" & encodeText(track_name, false, false) & "', 'album':'" & encodeText(track_album, false, false) & "', 'duration': '" & track_duration &"'}"
+end run
+
+
+# https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/EncodeandDecodeText.html
+on encodeText(theText, encodeCommonSpecialCharacters, encodeExtendedSpecialCharacters)
+    set theStandardCharacters to "abcdefghijklmnopqrstuvwxyz0123456789 "
+    set theCommonSpecialCharacterList to "$+!'/?;&@=#%><{}\"~`^\\|*"
+	set charList to "'"
+    set theExtendedSpecialCharacterList to ".-_:"
+    set theAcceptableCharacters to theStandardCharacters
+    if encodeCommonSpecialCharacters is false then set theAcceptableCharacters to theAcceptableCharacters & theCommonSpecialCharacterList
+    if encodeExtendedSpecialCharacters is false then set theAcceptableCharacters to theAcceptableCharacters & theExtendedSpecialCharacterList
+    set theEncodedText to ""
+    repeat with theCurrentCharacter in theText
+        if theCurrentCharacter is not in charList then
+			log theCurrentCharacter
+            set theEncodedText to (theEncodedText & theCurrentCharacter)
+        else
+            set theEncodedText to (theEncodedText & encodeCharacter(theCurrentCharacter)) as string
+        end if
+    end repeat
+    return theEncodedText
+end encodeText
+
+on encodeCharacter(theCharacter)
+    set theASCIINumber to (the ASCII number theCharacter)
+    set theHexList to {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"}
+    set theFirstItem to item ((theASCIINumber div 16) + 1) of theHexList
+    set theSecondItem to item ((theASCIINumber mod 16) + 1) of theHexList
+    return ("%" & theFirstItem & theSecondItem) as string
+end encodeCharacter

--- a/lib/applescript/Music/state.scpt
+++ b/lib/applescript/Music/state.scpt
@@ -1,0 +1,13 @@
+on run
+    set info to ""
+    tell application id "com.apple.Music"
+        if player state is paused then
+            set playerStateText to "Paused"
+        else if player state is playing then
+            set playerStateText to "Playing"
+        else
+            set playerStateText to "Stopped"
+        end if
+    end tell
+    return playerStateText
+end run

--- a/lib/applescript/iTunes/loop.scpt
+++ b/lib/applescript/iTunes/loop.scpt
@@ -1,0 +1,11 @@
+on run
+    set info to ""
+    tell application id "com.apple.iTunes"
+        if song repeat is off then
+            set playerStateText to false
+        else if song repeat is one or song repeat is all then
+            set playerStateText to true
+        end if
+    end tell
+    return playerStateText
+end run

--- a/lib/applescript/iTunes/nowplaying.scpt
+++ b/lib/applescript/iTunes/nowplaying.scpt
@@ -1,0 +1,47 @@
+on run
+	set info to ""
+	tell application id "com.apple.systemevents"
+		set num to count (every process whose bundle identifier is "com.apple.iTunes")
+	end tell
+	if num > 0 then
+		tell application id "com.apple.iTunes"
+			if player state is playing then
+				set track_name to name of current track
+				set track_artist to the artist of the current track
+				set track_album to the album of the  current track
+                set track_duration to (get duration of the current track)
+			end if
+		end tell
+	end if
+	return "{'artist':'" & encodeText(track_artist, false, false) & "', 'track': '" & encodeText(track_name, false, false) & "', 'album':'" & encodeText(track_album, false, false) & "', 'duration': '" & track_duration &"'}"
+end run
+
+
+# https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/EncodeandDecodeText.html
+on encodeText(theText, encodeCommonSpecialCharacters, encodeExtendedSpecialCharacters)
+    set theStandardCharacters to "abcdefghijklmnopqrstuvwxyz0123456789 "
+    set theCommonSpecialCharacterList to "$+!'/?;&@=#%><{}\"~`^\\|*"
+	set charList to "'"
+    set theExtendedSpecialCharacterList to ".-_:"
+    set theAcceptableCharacters to theStandardCharacters
+    if encodeCommonSpecialCharacters is false then set theAcceptableCharacters to theAcceptableCharacters & theCommonSpecialCharacterList
+    if encodeExtendedSpecialCharacters is false then set theAcceptableCharacters to theAcceptableCharacters & theExtendedSpecialCharacterList
+    set theEncodedText to ""
+    repeat with theCurrentCharacter in theText
+        if theCurrentCharacter is not in charList then
+			log theCurrentCharacter
+            set theEncodedText to (theEncodedText & theCurrentCharacter)
+        else
+            set theEncodedText to (theEncodedText & encodeCharacter(theCurrentCharacter)) as string
+        end if
+    end repeat
+    return theEncodedText
+end encodeText
+
+on encodeCharacter(theCharacter)
+    set theASCIINumber to (the ASCII number theCharacter)
+    set theHexList to {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"}
+    set theFirstItem to item ((theASCIINumber div 16) + 1) of theHexList
+    set theSecondItem to item ((theASCIINumber mod 16) + 1) of theHexList
+    return ("%" & theFirstItem & theSecondItem) as string
+end encodeCharacter

--- a/lib/applescript/iTunes/state.scpt
+++ b/lib/applescript/iTunes/state.scpt
@@ -1,0 +1,13 @@
+on run
+    set info to ""
+    tell application id "com.apple.iTUnes"
+        if player state is paused then
+            set playerStateText to "Paused"
+        else if player state is playing then
+            set playerStateText to "Playing"
+        else
+            set playerStateText to "Stopped"
+        end if
+    end tell
+    return playerStateText
+end run

--- a/lib/player.js
+++ b/lib/player.js
@@ -15,7 +15,7 @@ Runs nowplaying.scpt and gets json with information about current playing song f
 */
 function getCurrentPlaying() {
     return new Promise(function(resolve, reject) {
-        osascript.executeFile(__dirname + '/applescript/nowplaying.scpt', function(err, result, raw) {
+        osascript.executeFile(__dirname + '/applescript/' + process.player + '/nowplaying.scpt', function(err, result, raw) {
             if (err) {
                 console.log(err);
                 reject(Error(err));


### PR DESCRIPTION
Rather than rewriting scripts at runtime, keep separate copies of scripts for iTunes and scripts for apple Music and decide which script to use at runtime.

Tested on Catalina with initial values of `process.player` set to each of `"Music"`, `"iTunes"`, and `"x"`. 